### PR TITLE
Add Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,14 @@
+blank_issues_enabled: false
+contact_links:
+  - name: 🐛 SauceCTL Bug report
+    url: https://github.com/saucelabs/saucectl/issues/new?template=1-bug-report.md
+    about: Create a report to help us improve
+  - name: 🚀 Feature Proposal
+    url: https://github.com/saucelabs/saucectl/issues/new?template=feature.md
+    about: Submit a proposal for a new feature
+  # - name: 🤔 Questions and Help // TODO enable once doc section exists
+  #   url: https://docs.saucelabs.com/web-apps/automated-testing/replay/
+  #   about: Visit our documentation to review frequently asked questions and use cases
+  - name: 📃 Replay Example Issue
+    url: https://github.com/saucelabs/saucectl-replay-example/issues/new
+    about: Report any inaccurate or missing content


### PR DESCRIPTION
Direct users to the appropriate repo when filing reports.
The doc reference is disabled for now, as there are no docs for replay yet.